### PR TITLE
pass agent option to rawRequest for proxy

### DIFF
--- a/kraken.js
+++ b/kraken.js
@@ -28,11 +28,11 @@ const getMessageSignature = (path, request, secret, nonce) => {
 };
 
 // Send an API request
-const rawRequest = async (url, headers, data, timeout) => {
+const rawRequest = async (url, headers, data, timeout, agent) => {
 	// Set custom User-Agent string
 	headers['User-Agent'] = 'Kraken Javascript API Client';
 
-	const options = { headers, timeout };
+	const options = { headers, timeout, agent};
 
 	Object.assign(options, {
 		method : 'POST',
@@ -118,7 +118,7 @@ class KrakenClient {
 
 		const path     = '/' + this.config.version + '/public/' + method;
 		const url      = this.config.url + path;
-		const response = rawRequest(url, {}, params, this.config.timeout);
+		const response = rawRequest(url, {}, params, this.config.timeout, this.config.agent);
 
 		if(typeof callback === 'function') {
 			response
@@ -168,7 +168,7 @@ class KrakenClient {
 			'API-Sign' : signature,
 		};
 
-		const response = rawRequest(url, headers, params, this.config.timeout);
+		const response = rawRequest(url, headers, params, this.config.timeout, this.config.agent);
 
 		if(typeof callback === 'function') {
 			response


### PR DESCRIPTION
with got lib we can pass a proxy configuration with agent like  
[suggested in documentation]( https://github.com/sindresorhus/got ) 

```javascript
got('sindresorhus.com', {
	agent: tunnel.httpOverHttp({
		proxy: {
			host: 'localhost'
		}
	})
});
```

now when creating a KrakenClient we simply pass the agent like this: 
```javascript
const tunnel = require('tunnel'); 

var tunnelingAgent = tunnel.httpsOverHttp({
	proxy: {
	  host: 'proxyurl',
	  port: 80,
	  proxyAuth: 'user:pass',
	}
  });
const kraken       = new KrakenClient(key, secret,  {agent : tunnelingAgent});
```

all requests will be tunneled through proxy!